### PR TITLE
Laravel installer returns text instead of boolean, installation fails

### DIFF
--- a/InstallLaravel.php
+++ b/InstallLaravel.php
@@ -233,7 +233,7 @@ if (!$laravelInstaller) { // No installer found, use composer
 }
 print "{$color}Installing Laravel into [$targetDir]{$noColor}\n";
 $rc = system($cmd);
-if (!$rc === false) {
+if (!$laravelInstaller && !$rc === false) {
     die("System command [$cmd] failed ... exiting\n");
 }
 


### PR DESCRIPTION
I kept getting a `System command [laravel --no-interaction new schoolcore-2023] failed ... exiting` error when running the script. If I print out the value of the `$rc` variable, it gives the Laravel installer's `"Application ready! Build something amazing."` text. So instead of returning a boolean like a normal bash script would, it returns a string and therefore fails the logic check on line 236. My fix is probably a bad one, but it works for now.